### PR TITLE
ModelTextFilterTrait: Don't break if label is not a string

### DIFF
--- a/src/Snippets/ModelTextFilterTrait.php
+++ b/src/Snippets/ModelTextFilterTrait.php
@@ -55,6 +55,9 @@ trait ModelTextFilterTrait
                     if (isset($options[$field])) {
                         $inValues = [];
                         foreach ($options[$field] as $value => $label) {
+                            if (!is_string($label)) {
+                                continue;
+                            }
                             if (str_contains(strtolower($label), $search)) {
                                 $inValues[] = $value;
                             }


### PR DESCRIPTION
Fixes searching in gemstracker organizations, where the label of the gor_styles field is an array.